### PR TITLE
1.1.1 Missed another function needing to be set as static to avoid PHP issues.

### DIFF
--- a/gravity-forms-bulk-download.php
+++ b/gravity-forms-bulk-download.php
@@ -32,7 +32,7 @@ if (!class_exists('GFBulkDownload')) {
 			add_action('gform_delete_entry', ['GFBulkDownload', 'delete_entry_file_zip'], 10, 1);
 		}
 
-		function append_before_email_sent($notification, $form, $entry)
+		public static function append_before_email_sent($notification, $form, $entry)
 		{
 			$site = trailingslashit(get_bloginfo('url'));
 			$zip_path = gform_get_meta($entry['id'], 'zip_path');
@@ -51,7 +51,7 @@ if (!class_exists('GFBulkDownload')) {
 		{
 		}
 
-		function addMetaToDetails($form, $entry)
+		public static function addMetaToDetails($form, $entry)
 		{
 			$zip = gform_get_meta($entry['id'], 'zip_path');
 
@@ -123,7 +123,7 @@ if (!class_exists('GFBulkDownload')) {
 			}
 		}
 
-		function change_column_data($value, $form_id, $field_id, $lead, $query_string)
+		public static function change_column_data($value, $form_id, $field_id, $lead, $query_string)
 		{
 			$form = GFFormsModel::get_form_meta($form_id);
 			$zip_path = gform_get_meta($lead['id'], 'zip_path');
@@ -142,7 +142,7 @@ if (!class_exists('GFBulkDownload')) {
 			return $value;
 		}
 
-		function custom_merge_tags($merge_tags, $form_id, $fields, $element_id)
+		public static function custom_merge_tags($merge_tags, $form_id, $fields, $element_id)
 		{
 			$merge_tags[] = ['label' => 'Download All Files (Zip)', 'tag' => '{download_all_files_zip}'];
 			return $merge_tags;

--- a/gravity-forms-bulk-download.php
+++ b/gravity-forms-bulk-download.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gravity Forms Bulk Download
  * Plugin URI: http://stevecordle.net
  * Description: Bulk download files for file upload forms using Gravity Forms
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: Steve Cordle
  * Network: true
  * Author URI: http://stevecordle.net/
@@ -18,7 +18,7 @@ if (!class_exists('GFBulkDownload')) {
 	class GFBulkDownload
 	{
 		protected $name = 'Gravity Forms Bulk Download';
-		protected $version = '1.1.1';
+		protected $version = '1.1.2';
 
 		public static function init()
 		{

--- a/gravity-forms-bulk-download.php
+++ b/gravity-forms-bulk-download.php
@@ -43,11 +43,11 @@ if (!class_exists('GFBulkDownload')) {
 			return $notification;
 		}
 
-		public function addStyles()
+		public static function addStyles()
 		{
 		}
 
-		public function addScripts()
+		public static function addScripts()
 		{
 		}
 
@@ -71,7 +71,7 @@ if (!class_exists('GFBulkDownload')) {
 			}
 		}
 
-		public function preSubmissionFilter($form)
+		public static function preSubmissionFilter($form)
 		{
 			//Get upload path for form
 			$form_upload_dir = GFFormsModel::get_upload_path($form['id']);
@@ -105,7 +105,7 @@ if (!class_exists('GFBulkDownload')) {
 			return $form;
 		}
 
-		public function afterSubmission($entry, $form)
+		public static function afterSubmission($entry, $form)
 		{
 			//update the Entry with a zip_file meta field with a link to the zip file that was created.
 			if (isset($form['zip'])) {
@@ -113,7 +113,7 @@ if (!class_exists('GFBulkDownload')) {
 			}
 		}
 
-		public function delete_entry_file_zip($entry_id)
+		public static function delete_entry_file_zip($entry_id)
 		{
 			//getting entry object
 			$zip = gform_get_meta($entry_id, 'zip_path');
@@ -148,7 +148,7 @@ if (!class_exists('GFBulkDownload')) {
 			return $merge_tags;
 		}
 
-		function replace_download_link($text, $form, $entry, $url_encode, $esc_html, $nl2br, $format)
+		public static function replace_download_link($text, $form, $entry, $url_encode, $esc_html, $nl2br, $format)
 		{
 			$custom_merge_tag = '{download_all_files_zip}';
 			if (strpos($text, $custom_merge_tag) === false) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: stevecordle, kzeni
 Tags: gravity forms, bulk download
 Requires at least: 3.8
 Tested up to: 5.2.2
-Stable tag: 1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,6 +48,9 @@ No settings necessary, it will create a zip file automatically when multiple fil
 3. This shows the Notifications page where a new merge tag was added that can be used to display the link of the zip file {download_all_files_zip}
 
 == Changelog ==
+
+= 1.1.2 =
+* 1.1.1 Missed another function needing to be set as static to avoid PHP issues.
 
 = 1.1.1 =
 * Prevent fatal error in newer PHP ("non-static method GFBulkDownload::__construct() cannot be called statically".)


### PR DESCRIPTION
As such, I made that function among other public functions static.

This is untested, but it at least doesn't have a fatal PHP error on PHP 8 anymore.